### PR TITLE
Make textContainerInset specify-able

### DIFF
--- a/Sources/ResizingTextView/ResizingTextView.swift
+++ b/Sources/ResizingTextView/ResizingTextView.swift
@@ -18,8 +18,10 @@ public struct ResizingTextView: View, Equatable {
 #if os(macOS)
     var focusesNextKeyViewByTabKey: Bool = true
     var onInsertNewline: (() -> Bool)?
+    var textContainerInset: CGSize?
 #elseif os(iOS)
     var autocapitalizationType: UITextAutocapitalizationType = .sentences
+    var textContainerInset: UIEdgeInsets?
 #endif
     
 #if os(macOS)
@@ -113,7 +115,8 @@ public struct ResizingTextView: View, Equatable {
                     self.isFocused = false
                 }
             },
-            onInsertNewline: onInsertNewline
+            onInsertNewline: onInsertNewline,
+            textContainerInset: textContainerInset
         )
         .padding(.vertical, isEditable ? 8 : 0)
         .padding(.horizontal, isEditable ? 9 : 0)
@@ -136,7 +139,8 @@ public struct ResizingTextView: View, Equatable {
                 font: font,
                 canHaveNewLineCharacters: canHaveNewLineCharacters,
                 foregroundColor: Color(foregroundColor),
-                autocapitalizationType: autocapitalizationType)
+                autocapitalizationType: autocapitalizationType,
+                textContainerInset: textContainerInset)
             if let placeholder {
                 Text(placeholder)
                     .font(Font(font))

--- a/Sources/ResizingTextView/TextView (AppKit).swift
+++ b/Sources/ResizingTextView/TextView (AppKit).swift
@@ -18,19 +18,21 @@ struct TextView: NSViewRepresentable {
     var foregroundColor: Color
     var onFocusChanged: ((Bool) -> Void)?
     var onInsertNewline: (() -> Bool)?
+    var textContainerInset: CGSize
 
     init(_ text: Binding<String>,
-         placeholder: String? = nil,
-         isEditable: Bool = true,
-         isScrollable: Bool = false,
-         isSelectable: Bool = true,
-         lineLimit: Int = 0,
+         placeholder: String?,
+         isEditable: Bool,
+         isScrollable: Bool,
+         isSelectable: Bool,
+         lineLimit: Int,
          font: NSFont,
-         canHaveNewLineCharacters: Bool = true,
-         focusesNextKeyViewByTabKey: Bool = true,
-         foregroundColor: Color = defaultForegroundColor,
-         onFocusChanged: ((Bool) -> Void)? = nil,
-         onInsertNewline: (() -> Bool)? = nil
+         canHaveNewLineCharacters: Bool,
+         focusesNextKeyViewByTabKey: Bool,
+         foregroundColor: Color?,
+         onFocusChanged: ((Bool) -> Void)?,
+         onInsertNewline: (() -> Bool)?,
+         textContainerInset: CGSize?
     ) {
         self._text = text
         self.placeholder = placeholder
@@ -40,23 +42,16 @@ struct TextView: NSViewRepresentable {
         self.lineLimit = lineLimit
         self.canHaveNewLineCharacters = canHaveNewLineCharacters
         self.focusesNextKeyViewByTabKey = focusesNextKeyViewByTabKey
-        self.foregroundColor = foregroundColor
+        self.foregroundColor = foregroundColor ?? Self.defaultForegroundColor
         self.font = font
         self.onFocusChanged = onFocusChanged
         self.onInsertNewline = onInsertNewline
-    }
-
-    init(text: String) {
-        self.init(
-            Binding<String>.constant(text),
-            isEditable: false,
-            font: NSFont.preferredFont(forTextStyle: .body),
-            foregroundColor: Self.defaultForegroundColor)
+        self.textContainerInset = textContainerInset ?? CGSize(width: -5, height: 0)
     }
 
     func makeNSView(context: Context) -> TextEnclosingScrollView {
         let textView = CustomTextView()
-        textView.textContainerInset = .init(width: -5, height: 0)
+        textView.textContainerInset = textContainerInset
         textView.delegate = context.coordinator
         textView.isRichText = false
         textView.allowsUndo = true

--- a/Sources/ResizingTextView/TextView (UIKit).swift
+++ b/Sources/ResizingTextView/TextView (UIKit).swift
@@ -17,6 +17,7 @@ struct TextView: UIViewRepresentable {
     private var canHaveNewLineCharacters: Bool
     private var width: CGFloat?
     private var autocapitalizationType: UITextAutocapitalizationType
+    private var textContainerInset: UIEdgeInsets
 
     init(_ text: Binding<String>,
          isEditable: Bool,
@@ -26,7 +27,8 @@ struct TextView: UIViewRepresentable {
          font: UIFont,
          canHaveNewLineCharacters: Bool,
          foregroundColor: Color,
-         autocapitalizationType: UITextAutocapitalizationType) {
+         autocapitalizationType: UITextAutocapitalizationType,
+         textContainerInset: UIEdgeInsets?) {
         self._text = text
         self.isEditable = isEditable
         self.isScrollable = isScrollable
@@ -36,6 +38,10 @@ struct TextView: UIViewRepresentable {
         self.font = font
         self.canHaveNewLineCharacters = canHaveNewLineCharacters
         self.autocapitalizationType = autocapitalizationType
+        
+        // HACK: In iOS 17, the last sentence of a non-editable text may not be drawn if the textContainerInset is `.zero`. To avoid it, we add this default value to the insets.
+        let defaultTextContainerInset = UIEdgeInsets(top: 0.00000001, left: 0.00000001, bottom: 0.00000001, right: 0.00000001)
+        self.textContainerInset = textContainerInset ?? defaultTextContainerInset
     }
 
     func makeUIView(context: Context) -> CustomTextView {
@@ -88,7 +94,7 @@ struct TextView: UIViewRepresentable {
         }
 
         if !isEditable {
-            view.textContainerInset = .zero
+            view.textContainerInset = textContainerInset
             needsInvalidateIntrinsicContentSize = true
         }
 


### PR DESCRIPTION
Fixes #1

Now `ResizingTextView` has a `textContainerInset` property, which is `UIEdgeInsets` in iOS and `CGSize` in macOS. This is just a port of the same property of `UITextView` and `NSTextView`.

These are the default values:

- iOS: `UIEdgeInsets(top: 0.00000001, left: 0.00000001, bottom: 0.00000001, right: 0.00000001)`
- macOS: `CGSize(width: -5, height: 0)`

The default value for iOS is not `.zero` because if I set it zero, #1 occurs in iOS 17.
Perhaps it's a bug of iOS 17, but either way this could be useful for some cases so I exposed it.

This PR also includes some refactoring.