### PR TITLE
macOS: Make the padding inside the editable text view clickable

### DIFF
--- a/Sources/ResizingTextView/ResizingTextView.swift
+++ b/Sources/ResizingTextView/ResizingTextView.swift
@@ -118,10 +118,17 @@ public struct ResizingTextView: View, Equatable {
                 }
             },
             onInsertNewline: onInsertNewline,
-            textContainerInset: textContainerInset
+            textContainerInset: textContainerInset ?? {
+                var inset = CGSize(width: -5, height: 0)
+                inset.width += (isEditable ? 9 : 0)
+                inset.height += (isEditable ? 8 : 0)
+                return inset
+            }()
         )
+#if os(iOS)
         .padding(.vertical, isEditable ? 8 : 0)
         .padding(.horizontal, isEditable ? 9 : 0)
+#endif
         .background(isEditable ? Color(UXColor.controlBackgroundColor) : .clear)
         .roundedFilledBorder(
             isEditable ? Color(UXColor.separatorColor) : .clear,

--- a/Sources/ResizingTextView/ResizingTextView.swift
+++ b/Sources/ResizingTextView/ResizingTextView.swift
@@ -125,10 +125,6 @@ public struct ResizingTextView: View, Equatable {
                 return inset
             }()
         )
-#if os(iOS)
-        .padding(.vertical, isEditable ? 8 : 0)
-        .padding(.horizontal, isEditable ? 9 : 0)
-#endif
         .background(isEditable ? Color(UXColor.controlBackgroundColor) : .clear)
         .roundedFilledBorder(
             isEditable ? Color(UXColor.separatorColor) : .clear,

--- a/Sources/ResizingTextView/TextView (AppKit).swift
+++ b/Sources/ResizingTextView/TextView (AppKit).swift
@@ -33,7 +33,7 @@ struct TextView: NSViewRepresentable {
         foregroundColor: Color?,
         onFocusChanged: ((Bool) -> Void)?,
         onInsertNewline: (() -> Bool)?,
-        textContainerInset: CGSize?
+        textContainerInset: CGSize
     ) {
         self._text = text
         self.placeholder = placeholder
@@ -47,7 +47,7 @@ struct TextView: NSViewRepresentable {
         self.font = font
         self.onFocusChanged = onFocusChanged
         self.onInsertNewline = onInsertNewline
-        self.textContainerInset = textContainerInset ?? CGSize(width: -5, height: 0)
+        self.textContainerInset = textContainerInset
     }
 
     func makeNSView(context: Context) -> TextEnclosingScrollView {
@@ -138,6 +138,7 @@ struct TextView: NSViewRepresentable {
                 textView.textContainer?.lineBreakMode = .byTruncatingTail
             }
         }
+        
         if !context.coordinator.selectedRanges.isEmpty,
            textView.selectedRanges != context.coordinator.selectedRanges {
             textView.selectedRanges = context.coordinator.selectedRanges


### PR DESCRIPTION
Now, the padding inside an editable text view is set with `NSTextView`'s `textContainerInset` rather than `.padding()` so that the padding is also clickable.

Also, as a good side effect, now the user can fully control the padding of the editable text view by themselves since it no longer set the hard-coded `.padding()`.

This may be breaking for those who set `textContainerInset` manually.

## Before

https://github.com/mshibanami/ResizingTextView/assets/1333214/b2b63054-1031-42ff-9e68-0c54e916b08a

## After

https://github.com/mshibanami/ResizingTextView/assets/1333214/ab76d14d-6146-4991-81be-0b71cfdb5909
